### PR TITLE
Feat: Implementation of TopicModeling baseline #17

### DIFF
--- a/notebooks/TopicModeling/TopicModeling_baseline.ipynb
+++ b/notebooks/TopicModeling/TopicModeling_baseline.ipynb
@@ -1,0 +1,472 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from tqdm import tqdm\n",
+    "import pickle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('/home/user/interaction_240113_final.csv')\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# user별 interaction 개수를 계산\n",
+    "user_interaction_counts = df['hashed_ip'].value_counts()\n",
+    "# interaction이 3개 이상인 user의 목록을 가져옴\n",
+    "selected_users = user_interaction_counts[user_interaction_counts >= 3].index\n",
+    "# interaction이 3개 이상인 user에 대한 데이터만 남김\n",
+    "df = df[df['hashed_ip'].isin(selected_users)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('/home/user/product_info_df.pickle', 'rb') as fr:\n",
+    "    product_info = pickle.load(fr)\n",
+    "product_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "product_data = product_info.copy()\n",
+    "product_data['title'] = product_data['title'].map(lambda x: x.replace(\"'\",'').replace(',','').replace('(', ' ').replace(')', ' '))\n",
+    "product_data['title'] = product_data['title'].map(lambda x: x.lower())\n",
+    "product_data['title'] = product_data['title'].map(lambda x: x.split(' '))\n",
+    "product_data['title'] = product_data['title'].map(lambda x: ' '.join(x).split())\n",
+    "product_data['title'] = product_data['title'].map(lambda x: ' '.join(x))\n",
+    "product_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## piv를 product_id로 변환하기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# piv:id dict 만들기\n",
+    "piv_id_dict = { product_info.loc[i, 'piv']:product_info.loc[i, 'id'] for i in tqdm(range(len(product_info)))}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# piv 있는 행과 없는 행 구분하기(속도를 위해 구분)\n",
+    "product_id_df = df[df['products'].str.contains('-') == False]\n",
+    "piv_df = df[df['products'].str.contains('-')]\n",
+    "\n",
+    "# piv를 product_id로 바꾸기\n",
+    "piv_df['products'] = piv_df['products'].map(piv_id_dict)\n",
+    "\n",
+    "# piv 있는 행과 없는 행 다시 concat하기\n",
+    "data = pd.concat([product_id_df, piv_df], axis=0, ignore_index=False)\n",
+    "data = data.sort_index()\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# hashed_ip별 상호작용한 아이템 목록\n",
+    "user_items=data.groupby('hashed_ip')['products'].apply(set).apply(list).to_dict()\n",
+    "user_items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data[data['products'].str.contains('-')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating view document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_drop_local_time = data.drop(columns='local_time', axis=0)\n",
+    "grouped = data_drop_local_time.groupby('hashed_ip')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_document = []\n",
+    "last_view = []\n",
+    "for hashed_ip, session in grouped:\n",
+    "    if len(session) > 1:\n",
+    "        view_document.append(session['products'][:-1].astype(str).to_list())\n",
+    "        last_view.append(session['products'][-1:].astype(str).to_list())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating dictionary of products"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dict_products = product_data[['id','title']].set_index('id').to_dict()['title']\n",
+    "dict_products"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['products_name']=data['products'].map(dict_products)\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_items=data.groupby('hashed_ip')['products_name'].apply(set).apply(list).to_dict()\n",
+    "user_items"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(dict_products))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TopicModeling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install gensim\n",
+    "!pip install pyLDAvis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gensim.parsing.preprocessing import preprocess_string\n",
+    "from gensim.corpora import Dictionary\n",
+    "from gensim.models import LdaModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "documents = list(user_items.values())\n",
+    "dictionary = Dictionary(documents)\n",
+    "corpus = [dictionary.doc2bow(document) for document in documents]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### optimize num_topics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gensim\n",
+    "from gensim.models import CoherenceModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topic_range = range(2, 21)\n",
+    "coherence_scores = []\n",
+    "for num_topics in topic_range:\n",
+    "    lda_model = LdaModel(corpus=corpus, id2word=dictionary, num_topics=num_topics, passes=10)\n",
+    "    coherence_model = CoherenceModel(model=lda_model, texts=documents, dictionary=dictionary, coherence='c_v')\n",
+    "    coherence_score = coherence_model.get_coherence()\n",
+    "    coherence_scores.append(coherence_score)\n",
+    "    print(f\"Num Topics: {num_topics}, Coherence Score: {coherence_score}\")\n",
+    "\n",
+    "optimal_num_topics = topic_range[np.argmax(coherence_scores)]\n",
+    "print(f\"Optimal Number of Topics: {optimal_num_topics}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## train"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_topics = 5\n",
+    "lda_model = LdaModel(corpus=corpus, id2word=dictionary, num_topics=num_topics, random_state=42, passes=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Check details(optional)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# topic확인\n",
+    "topics = lda_model.print_topics(num_words=5)\n",
+    "for topic in topics:\n",
+    "    print(topic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 각 사용자에 대한 토픽 분포\n",
+    "for i, row_list in enumerate(lda_model[corpus]):\n",
+    "    print(f\"User {list(user_items.keys())[i]}'s topic distribution: {row_list}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 각 아이템의 토픽 분포 확인\n",
+    "# result: (토픽 번호, 토픽에 속할 확률)\n",
+    "user_embeddings = [lda_model.get_document_topics(item) for item in corpus]\n",
+    "user_embeddings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 각 아이템의 토픽 분포 확인\n",
+    "# result: (토픽 번호, 토픽에 속할 확률)\n",
+    "for doc_topics in lda_model.get_document_topics(corpus):\n",
+    "    print(doc_topics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 예시\n",
+    "user_index = list(user_items.keys()).index('000d993b424a2e62dc24078df07d551a')\n",
+    "user_index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# user vector\n",
+    "doc_id = 153  # 조회하고 싶은 사용자 ID\n",
+    "doc_bow = corpus[doc_id]\n",
+    "doc_topics = lda_model.get_document_topics(doc_bow, minimum_probability=0)\n",
+    "\n",
+    "print(f\"Document #{doc_id} Topics:\")\n",
+    "for topic, prob in doc_topics:\n",
+    "    print(f\"Topic {topic}: {prob}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pid로 학습한 경우 사용\n",
+    "# def details_of_related_items(topic_index):\n",
+    "#     print(f\"Topic #{topic_index}:\")\n",
+    "#     print('-'*50)\n",
+    "#     for word_id, prob in lda_model.get_topic_terms(topic_index, topn=30):\n",
+    "#         print(f\"{dictionary[word_id]} {dict_products[dictionary[word_id]]} (확률: {prob:.10f})\")\n",
+    "\n",
+    "def details_of_related_items(topic_index):\n",
+    "    print(f\"Topic #{topic_index}:\")\n",
+    "    print('-'*50)\n",
+    "    for word_id, prob in lda_model.get_topic_terms(topic_index, topn=30):\n",
+    "        print(f\"{dictionary[word_id]} (확률: {prob:.10f})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(5):\n",
+    "    print(f\"--------------------{i}--------------------\")\n",
+    "    details_of_related_items(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyLDAvis\n",
+    "import pyLDAvis.gensim_models as gensimvis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vis_data = gensimvis.prepare(lda_model, corpus, dictionary)\n",
+    "pyLDAvis.display(vis_data)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.18 ('test': conda)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0a6f8b45af1aebb989f3a6bef1d64b68316b6214ed3f64b3b1b4e0eb810a54a3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Overview
- 카카오 추천 팀의 알고리즘과 쿠팡의 Filtering+Boosting 메커니즘을 참고하여 토픽 모델링을 적용해 최종 추천 모델 성능을 올리고자 구현함
- 1차 필터링 용도로 사용할 수 있음
- 새로운 사용자나 아이템에 대해 모델을 다시 학습하지 않아도 된다는 이점을 가짐

## Change Log
- TopicModeling baseline
- 토픽 분포나 사용자 벡터를 확인할 수 있도록 check details 코드 추가

## To Reviewer
- 해당 모델로 표현되는 사용자, 아이템 벡터들을 이용해 side info를 활용한 모델에 적용해 보면 좋을 것 같습니다.

## Issue Tags
- resolved: #17
